### PR TITLE
fix elasticsearch for arm64

### DIFF
--- a/patches/elasticsearch/7.16/docker/Dockerfile.install
+++ b/patches/elasticsearch/7.16/docker/Dockerfile.install
@@ -15,3 +15,5 @@ RUN mkdir -p /opt/bitnami \
     && mv elasticsearch-${ELASTICSEARCH_VERSION}/ elasticsearch \
     && rm -rf elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(uname -m)* \
     && chown 1001:1001 -R /opt/bitnami/elasticsearch
+
+RUN  mv /opt/bitnami/elasticsearch/config/elasticsearch.yml /opt/bitnami/elasticsearch/config/es_config.sample

--- a/patches/elasticsearch/7.17/docker/Dockerfile.install
+++ b/patches/elasticsearch/7.17/docker/Dockerfile.install
@@ -15,3 +15,5 @@ RUN mkdir -p /opt/bitnami \
     && mv elasticsearch-${ELASTICSEARCH_VERSION}/ elasticsearch \
     && rm -rf elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(uname -m)* \
     && chown 1001:1001 -R /opt/bitnami/elasticsearch
+
+RUN  mv /opt/bitnami/elasticsearch/config/elasticsearch.yml /opt/bitnami/elasticsearch/config/es_config.sample

--- a/patches/elasticsearch/8.3/docker/Dockerfile.install
+++ b/patches/elasticsearch/8.3/docker/Dockerfile.install
@@ -15,3 +15,5 @@ RUN mkdir -p /opt/bitnami \
     && mv elasticsearch-${ELASTICSEARCH_VERSION}/ elasticsearch \
     && rm -rf elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(uname -m)* \
     && chown 1001:1001 -R /opt/bitnami/elasticsearch
+
+RUN  mv /opt/bitnami/elasticsearch/config/elasticsearch.yml /opt/bitnami/elasticsearch/config/es_config.sample


### PR DESCRIPTION
thanks for provide the way to build bitnami arm image
i find a issues that the elasticsearch provided by bitnami have no file wiht elasticsearch.yaml (the file is rename to es_config.sample), but the official have。
bitnami tar :https://downloads.bitnami.com/files/stacksmith/elasticsearch-8.3.2-1-linux-amd64-debian-11.tar.gz
official tar :https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.3.2-linux-aarch64.tar.gz
if the file exists, bitnami will set no any config to file and  elasticsearch will  run failed
![image](https://user-images.githubusercontent.com/43570712/185115833-b800b11b-cd5d-412a-9011-a47518fbdbc9.png)

