### PR TITLE
Fixed corrupted JAR in jmx-exporter

### DIFF
--- a/patches/jmx-exporter/0.17/docker/Dockerfile.install
+++ b/patches/jmx-exporter/0.17/docker/Dockerfile.install
@@ -1,7 +1,7 @@
 ENV JMX_EXPORTER_VERSION {{{VERSION}}}
 RUN install_packages curl tar \
  && mkdir -p /opt/bitnami/jmx-exporter \
- && curl -L -o /opt/bitnami/jmx-exporter/jmx_prometheus_httpserver.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/${JMX_EXPORTER_VERSION}/jmx_prometheus_httpserver-${JMX_EXPORTER_VERSION}-jar-with-dependencies.jar \
+ && curl -L -o /opt/bitnami/jmx-exporter/jmx_prometheus_httpserver.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/${JMX_EXPORTER_VERSION}/jmx_prometheus_httpserver-${JMX_EXPORTER_VERSION}.jar \
  && curl -L -o /opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar \
  && curl -L -o /opt/bitnami/jmx-exporter/LICENSE-2.0.txt http://www.apache.org/licenses/LICENSE-2.0.txt \
  && curl -L -o parent-${JMX_EXPORTER_VERSION}.tar.gz https://github.com/prometheus/jmx_exporter/archive/refs/tags/parent-${JMX_EXPORTER_VERSION}.tar.gz \


### PR DESCRIPTION
URL to JAR of jmx_prometheus_httpserver have been changed, see https://github.com/prometheus/jmx_exporter/releases/tag/parent-0.17.2

Tested it locally with ARM64, works when using https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/0.17.2/jmx_prometheus_httpserver-0.17.2.jar